### PR TITLE
Upgrade to RectorPHP v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "rector/rector": "^1.0"
+        "rector/rector": "^2.0"
     },
     "require-dev": {
         "contao/easy-coding-standard": "^6.12"

--- a/src/Rector/SimplifyObjectOrNullCheckRector.php
+++ b/src/Rector/SimplifyObjectOrNullCheckRector.php
@@ -22,10 +22,11 @@ use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\PhpParser\Node\Value\ValueResolver;
 use Rector\Rector\AbstractRector;
 use Rector\TypeDeclaration\TypeAnalyzer\NullableTypeAnalyzer;
+use Symplify\RuleDocGenerator\Contract\DocumentedRuleInterface;
 use Symplify\RuleDocGenerator\ValueObject\CodeSample\CodeSample;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
-final class SimplifyObjectOrNullCheckRector extends AbstractRector
+final class SimplifyObjectOrNullCheckRector extends AbstractRector implements DocumentedRuleInterface
 {
     public function __construct(
         private readonly NullableTypeAnalyzer $nullableTypeAnalyzer,

--- a/src/Set/SetList.php
+++ b/src/Set/SetList.php
@@ -12,9 +12,7 @@ declare(strict_types=1);
 
 namespace Contao\Rector\Set;
 
-use Rector\Set\Contract\SetListInterface;
-
-final class SetList implements SetListInterface
+final class SetList
 {
     public const CONTAO = __DIR__.'/../../config/contao.php';
 }


### PR DESCRIPTION
### Description

* Bump the dependency (RectorPHP ^2.0)
* Remove the deprecated `SetListInterface`
* implement the `DocumentedRuleInterface` for custom rules within Rectors - you actually do not need them anymore unless you want to generate documentation for your rules in a [markdown file](https://github.com/contao/contao-rector/blob/main/docs/rules_overview.md) (:

### Note

I ran RectorPHP `2.x` against the current `5.x` branch and the following will be changed:

```diff
> @php vendor-bin/rector/vendor/bin/rector
 0/7 [>---------------------------]   0% 7/7 [============================] 100%
7 files with changes
====================

1) core-bundle/src/Controller/SitemapController.php:1

    ---------- begin diff ----------
@@ @@
 #Warning: Strings contain different line endings!
 <?php

 declare(strict_types=1);
@@ @@
         $urls = array_unique($urls);

         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $sitemap->formatOutput = true;
+        $sitemap->formatOutput = true;
+        
         $urlSet = $sitemap->createElementNS('https://www.sitemaps.org/schemas/sitemap/0.9', 'urlset');

         foreach ($urls as $url) {
    ----------- end diff -----------

Applied rules:
 * NewlineBeforeNewAssignSetRector


2) core-bundle/src/DataContainer/DataContainerOperationsBuilder.php:1

    ---------- begin diff ----------
@@ @@
 #Warning: Strings contain different line endings!
 <?php

 declare(strict_types=1);
@@ @@

         $xml = new \DOMDocument();
         $xml->preserveWhiteSpace = false;
-        $xml->loadHTML('<?xml encoding="UTF-8">'.$operation['html']);
+        $xml->loadHTML('<?xml encoding="UTF-8">'.$operation['html']);
+        
         $body = $xml->getElementsByTagName('body')[0];

         if ($body->childNodes->length < 2) {
    ----------- end diff -----------

Applied rules:
 * NewlineBeforeNewAssignSetRector


3) core-bundle/src/DataContainer/PaletteManipulator.php:129

    ---------- begin diff ----------
@@ @@
         }

         // Make sure there is at least one legend
-        if (0 === \count($config)) {
+        if ([] === $config) {
             $config = [['fields' => [], 'hide' => false]];
         }
    ----------- end diff -----------

Applied rules:
 * CountArrayToEmptyArrayComparisonRector


4) core-bundle/src/Twig/Runtime/PictureConfigurationRuntime.php:46

    ---------- begin diff ----------
@@ @@
             function (array $itemConfig): PictureConfigurationItem {
                 $sizeItem = $this->createPictureConfigurationItem($itemConfig);

-                if (!empty($itemConfig)) {
+                if ($itemConfig !== []) {
                     $this->throwInvalidArgumentException($itemConfig, 'items');
                 }

@@ @@
         // Apply remaining data to root config
         $this->applyConfiguration($pictureConfiguration, $config);

-        if (!empty($config)) {
+        if ($config !== []) {
             $this->throwInvalidArgumentException($config);
         }
    ----------- end diff -----------

Applied rules:
 * SimplifyEmptyCheckOnEmptyArrayRector


5) core-bundle/tests/EventListener/SubrequestCacheSubscriberTest.php:1

    ---------- begin diff ----------
@@ @@
 #Warning: Strings contain different line endings!
 <?php

 declare(strict_types=1);
@@ @@
         $this->onKernelResponse($subscriber, $subResponse, HttpKernelInterface::SUB_REQUEST);

         $mainResponse = new Response();
-        $mainResponse->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, '1');
+        $mainResponse->headers->set(SubrequestCacheSubscriber::MERGE_CACHE_HEADER, '1');
+        
         $subResponse->setPublic();
         $mainResponse->setMaxAge(60);
    ----------- end diff -----------

Applied rules:
 * NewlineBeforeNewAssignSetRector


6) core-bundle/tests/EventListener/TransportSecurityHeaderListenerTest.php:1

    ---------- begin diff ----------
@@ @@
 #Warning: Strings contain different line endings!
 <?php

 declare(strict_types=1);
@@ @@
     public function testIgnoresIfTheResponseAlreadyHasAnStsHeaderPresent(): void
     {
         $response = new Response();
-        $response->headers->set('Strict-Transport-Security', 'max-age=500; includeSubDomains; preload');
+        $response->headers->set('Strict-Transport-Security', 'max-age=500; includeSubDomains; preload');
+        
         $request = Request::create('https://contao.org');

         $listener = new TransportSecurityHeaderListener($this->createScopeMatcher(true), 31536000);
    ----------- end diff -----------

Applied rules:
 * NewlineBeforeNewAssignSetRector


7) core-bundle/tests/Event/SitemapEventTest.php:1

    ---------- begin diff ----------
@@ @@
 #Warning: Strings contain different line endings!
 <?php

 declare(strict_types=1);
@@ @@
     public function testAddingUrlsToExistingUrlSetDoesNotFailIfThereIsNoUrlSet(): void
     {
         $sitemap = new \DOMDocument('1.0', 'UTF-8');
-        $sitemap->preserveWhiteSpace = false;
+        $sitemap->preserveWhiteSpace = false;
+        
         $event = new SitemapEvent($sitemap, new Request(), []);
         $event->addUrlToDefaultUrlSet('https://contao.org');
    ----------- end diff -----------

Applied rules:
 * NewlineBeforeNewAssignSetRector


 [OK] 7 files have been changed by Rector                                                                              
```